### PR TITLE
Added jshint tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+    "browser": true,
+    "devel": true,
+    "undef": true,
+    "trailing": true,
+    "quotmark": false,
+    "indent": 4,
+    "unused": "vars",
+    "latedef": "nofunc",
+    "globals": {
+        "module": false,
+        "exports": false,
+        "require": false,
+        "cordova": true,
+        "jasmineRequire": false
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,28 +1,35 @@
 {
-  "name": "cordova-plugin-nativestorage",
-  "version": "1.0.8",
-  "description": "Native storage of primitives in Android and iOS (booleans, strings, ints, doubles)",
-  "cordova": {
-    "id": "cordova-plugin-nativestorage",
-    "platforms": [
-      "android",
-      "ios"
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gillesC/cordova-plugin-nativestorage"
-  },
-  "keywords": [
-    "cordova",
-    "device",
-    "ecosystem:cordova",
-    "cordova-android",
-    "cordova-ios",
-    "localstorage", 
-    "NSUserDefaults", 
-    "SharedPreferences"
-  ],
-  "author": "Gilles Callebaut",
-  "license": "Apache-2.0"
+    "name": "cordova-plugin-nativestorage",
+    "version": "1.0.8",
+    "description": "Native storage of primitives in Android and iOS (booleans, strings, ints, doubles)",
+    "cordova": {
+        "id": "cordova-plugin-nativestorage",
+        "platforms": [
+            "android",
+            "ios"
+        ]
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/gillesC/cordova-plugin-nativestorage"
+    },
+    "scripts": {
+        "test": "npm run jshint",
+        "jshint": "jshint www"
+    },
+    "keywords": [
+        "cordova",
+        "device",
+        "ecosystem:cordova",
+        "cordova-android",
+        "cordova-ios",
+        "localstorage",
+        "NSUserDefaults",
+        "SharedPreferences"
+    ],
+    "author": "Gilles Callebaut",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "jshint": "^2.9.1"
+    }
 }


### PR DESCRIPTION
added jshint as a dev dependancy and setup `npm test` to run it on the `www` folder. After this useful  to integrate travis later.