### PR TITLE
Fixed inBrowser checking

### DIFF
--- a/www/NativeStorage.js
+++ b/www/NativeStorage.js
@@ -2,7 +2,7 @@ var exec = require('cordova/exec');
 var TAG = "NativeStorage.js";
 
 function inBrowser() {
-    return (window.cordova && window.cordova.platformId === 'browser') || !window.phonegap || !window.cordova;
+    return (window.cordova && window.cordova.platformId === 'browser') || !(window.phonegap || window.cordova);
 }
 
 /* Method for storage in localstorage if run in browser */

--- a/www/NativeStorage.js
+++ b/www/NativeStorage.js
@@ -9,7 +9,7 @@ function inBrowser() {
 NativeStorage.prototype.setInLocalStorage = function (reference, variable, success, error) {
     try {
         var varAsString = JSON.stringify(variable);
-        console.log("Saving: "+varAsString);
+        console.log("LocalStorage Saving: "+varAsString);
         localStorage.setItem(reference, varAsString);
         success(varAsString);
     } catch (err) {
@@ -21,7 +21,7 @@ NativeStorage.prototype.setInLocalStorage = function (reference, variable, succe
 NativeStorage.prototype.getFromLocalStorage = function (reference, success, error) {
     try {
         var obj = JSON.parse(localStorage.getItem(reference));
-        console.log("Reading: "+obj);
+        console.log("LocalStorage Reading: "+obj);
         success(obj);
     } catch (err) {
         error(err);


### PR DESCRIPTION
`!(window.phonegap || window.cordova)` returns true if and only if both options are not available. The previous version which was used  `!window.phonegap || !window.cordova` would return true if either one of them is not present. This means users with cordova but not phonegap for example will get inBrowser as true.