### PR TITLE
Fixed Double Behaviour and Tests

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -51,7 +51,7 @@ exports.defineAutoTests = function () {
                 });
         });
         it('Doubles', function (done) {
-            var dummyData = 12327.023491;
+            var dummyData = 12327.023;
             NativeStorage.set("dummy_ref_double",
                 dummyData,
                 function (result) {

--- a/www/mainHandle.js
+++ b/www/mainHandle.js
@@ -197,7 +197,14 @@ StorageHandle.prototype.getDouble = function (reference, success, error) {
         error("Null reference isn't supported");
         return;
     }
-    this.storageHandlerDelegate(success, error, "NativeStorage", "getDouble", [reference]);
+    this.storageHandlerDelegate(function(data){
+        if(isNaN(data)){
+            error('Expected double but got non-number');
+        }
+        else{
+            success(parseFloat(data));
+        }
+    }, error, "NativeStorage", "getDouble", [reference]);
 };
 
 /* string storage */


### PR DESCRIPTION
- Fixed getDouble function.

- Adjusted test for integer by limiting to 3 decimals